### PR TITLE
Fixed non-functional documentation typos

### DIFF
--- a/hw/3ds-touch/main.cpp
+++ b/hw/3ds-touch/main.cpp
@@ -19,7 +19,7 @@ const int PIN_Y_READ = A6;
 const float VCC = 4.59; // measured while plugged into usb
 const float VMAX = 1.8;
 const uint16_t SCALE = uint16_t(4095 * VMAX / VCC);
-const uint16_t SCALE_Y = SCALE - 21;  // slightly innaccurate DACs?
+const uint16_t SCALE_Y = SCALE - 21;  // slightly inaccurate DACs?
 const uint16_t SCALE_X = SCALE + 4;
 
 const uint8_t DAC_Y = 0x62;

--- a/hw/joycon/main.cpp
+++ b/hw/joycon/main.cpp
@@ -14,7 +14,7 @@ const float VCC = 4.59; // measured while plugged into usb
 const float VMAX = 1.8;
 const uint16_t SCALE = uint16_t(4095 * VMAX / VCC);
 
-const uint16_t Y_MAX = SCALE + 4;  // slightly innaccurate DACs?
+const uint16_t Y_MAX = SCALE + 4;  // slightly inaccurate DACs?
 const uint16_t Y_MID = Y_MAX * .8 / 1.8;
 const uint16_t Y_MIN = 0;
 

--- a/scripts/sv/dolliv_sandwich.py
+++ b/scripts/sv/dolliv_sandwich.py
@@ -177,7 +177,7 @@ def main() -> int:
                     Press('A'), Wait(10),
                     # confirm
                     Press('A'), Wait(25),
-                    # noice
+                    # noise
                     Press('A'), Wait(5),
                     reset_timer.after(29 * 60),
                 ),


### PR DESCRIPTION
This PR cleans up several misspellings and inconsistent wording.

### Updates:
- `hw/3ds-touch/main.cpp`, line 22: `innaccurate` → `inaccurate`
- `hw/joycon/main.cpp`, line 17: `innaccurate` → `inaccurate`
- `scripts/sv/dolliv_sandwich.py`, line 180: `noice` → `noise`

The logic and functionality of the code remain unaffected.