### PR TITLE
remove unnecessary args from add-trailing-comma

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: add-trailing-comma
-        args: [--py36-plus]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.20.0
     hooks:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos